### PR TITLE
Define STRICT_R_HEADERS, include cfloat for DBL_MIN

### DIFF
--- a/src/precrec_misc.cpp
+++ b/src/precrec_misc.cpp
@@ -1,7 +1,9 @@
+#define STRICT_R_HEADERS
 #include <Rcpp.h>
 #include <vector>
 #include <string>
 #include <ctime>
+#include <cfloat>       // DBL_MIN, DBL_MAX
 
 /*
 ##############################################

--- a/src/precrec_mmx.cpp
+++ b/src/precrec_mmx.cpp
@@ -1,3 +1,4 @@
+#define STRICT_R_HEADERS
 #include <Rcpp.h>
 #include <vector>       // std::vector
 #include <string>       // std::string

--- a/src/precrec_plx.cpp
+++ b/src/precrec_plx.cpp
@@ -1,3 +1,4 @@
+#define STRICT_R_HEADERS
 #include <Rcpp.h>
 #include <vector>
 #include <cmath>


### PR DESCRIPTION
Dear Takaya,

Your CRAN package precrect uses Rcpp, and is affected if we add a definition of STRICT_R_HEADERS as we would like to do. Please see the discussion at https://github.com/RcppCore/Rcpp/issues/1158 and the links therein for more context on this.

Here we prefixing each #include <Rcpp.h> with STRICT_R_HEADERS and include cfloat (or float.h, C style) in one file so that DBL_MIN is defined (as you already had in another file). No other changes were made.

It would be lovely if you could apply this. There is no strong urgency: we aim to get this done over all affected packages in the space of a few months. If you apply it, would you mind dropping me a note by email or swinging by https://github.com/RcppCore/Rcpp/issues/1158 to confirm?

Many thanks for your help, and I hope you continue to find Rcpp helpful. Please don't hesitate to ask if you have any questions.
